### PR TITLE
Add nix derivation and nix develop

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +947,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -1037,6 +1044,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.0.8",
+ "winsafe",
 ]
 
 [[package]]
@@ -1275,6 +1293,12 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ crossterm = "0.28"
 terminput = "0.4"
 terminput-crossterm = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+which = "8.0.0"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,52 @@ brew tap dkoontz/typeypipe
 brew install typeypipe
 ```
 
+### Nix (Flakes)
+
+Add this to your flake inputs:
+
+```nix
+  typeypipe-flake = {
+    url = "github:dkoontz/TypeyPipe";
+  };
+```
+
+Make sure to pass the input (or all of your flake inputs) to `specialArgs`:
+
+```nix
+{
+  inputs = {
+    # ... other inputs.
+    typeypipe-flake = {
+      url = "github:dkoontz/TypeyPipe";
+    };
+  };
+
+  outputs = flake-inputs@{
+    nixpkgs,
+    typeypipe-flake,
+    self,
+    ...
+  }: {
+    # Use darwinConfigurations and `nix-darwin.li.darwinSystem` for macOS, and
+    # make sure your platform and hostname match.
+    nixosConfigurations.aarch64-linux.my-host = nixpkgs.lib.nixosSystem {
+       specialArgs = {
+          inherit flake-inputs;
+          system = "aarch64-linux";
+       };
+       modules = [
+         ({ flake-inputs, system, ... }: {
+            environment.systemPackages = [
+              flake-inputs.typeypipe-flake.packages.${system}.default
+            ];
+         })
+       ];
+    };
+  };
+}
+```
+
 ### Manual Installation
 
 Download the latest release for your platform from [GitHub Releases](https://github.com/dkoontz/TypeyPipe/releases/latest):

--- a/derivation.nix
+++ b/derivation.nix
@@ -1,0 +1,37 @@
+{
+  cargo,
+  darwin,
+  lib,
+  libgit2,
+  libssh2,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  ...
+}:
+rustPlatform.buildRustPackage (let
+  cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+  # It is common convention in the Nix community to use
+  # "<last-release-version>-unstable-<date>" on non-release versions of a given
+  # package.  Unfortunately that is impossible to do with required tools like
+  # `builtins.fetchGit` because they violate flake purity.  So just stamp the
+  # version from what we see in `Cargo.toml` and if "unstable" is needed, this
+  # can be done by hand.
+  version = cargoToml.package.version;
+in {
+  pname = cargoToml.package.name;
+  inherit version;
+  src = ./.;
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
+  buildInputs = [
+  ];
+  nativeBuildInputs = [
+    cargo
+    # So cargo can find our various "lib" packages.  Might not be needed.
+    # Verify.
+    pkg-config
+  ];
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1754448563,
+        "narHash": "sha256-JdgvzorJa4h2RSjIUj+rEYDCdQl1ubqoS8WebYJjQ2s=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "1bee06db858d83014983af40e9d1cfca96c32f7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "";
+  inputs = {
+    # Forgive me.
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { self, flake-utils, nixpkgs, rust-overlay }@inputs: let
+    shell-overlays = [
+      (import rust-overlay)
+      (final: prev: {
+        # Use final so we can benefit from rust-overlay.
+        # This will include cargo, rustfmt, and other things from Rust.
+        rust-pinned = prev.rust-bin.stable.latest.default.override {
+          extensions = [
+            # For rust-analyzer and others.  See
+            # https://nixos.wiki/wiki/Rust#Shell.nix_example for some details.
+            "clippy"
+            "rust-analyzer"
+            "rust-src"
+            "rustfmt"
+          ];
+        };
+      })
+    ];
+  in (flake-utils.lib.eachDefaultSystem (system: (let
+    pkgs = import nixpkgs {
+      overlays = shell-overlays;
+      inherit system;
+    };
+  in {
+    devShells.default = pkgs.mkShell {
+      buildInputs = [
+        pkgs.cargo
+        pkgs.rust-pinned
+      ];
+    };
+
+    packages.default = pkgs.callPackage ./derivation.nix {};
+    defaultPackage = self.packages.${system}.default;
+  }))) // {
+    overlays.default = final: prev: {
+      repo-sync = prev.callPackage ./derivation.nix {};
+    };
+  };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,16 @@
 use anyhow::Result;
 use clap::{Arg, Command};
+use std::{env, path::PathBuf, ffi::OsStr};
 use typey_pipe::shell::ShellConfig;
+use which::which;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let default_shell_path: &'static OsStr = Box::leak(Box::new(which("bash")
+        .or_else(|_| env::var("SHELL").map(PathBuf::from))
+        .unwrap_or_else(|_| PathBuf::from("bash"))
+        .into_os_string()
+    )).as_os_str();
     let matches = Command::new("typeypipe")
         .version(env!("CARGO_PKG_VERSION"))
         .about("Transparent shell messaging system")
@@ -12,8 +19,8 @@ async fn main() -> Result<()> {
                 .short('s')
                 .long("shell")
                 .value_name("SHELL")
-                .help("Shell to use (default: /bin/bash)")
-                .default_value("/bin/bash")
+                .help("Shell to use")
+                .default_value_os(default_shell_path)
         )
         .arg(
             Arg::new("queue-dir")

--- a/src/shell/pty.rs
+++ b/src/shell/pty.rs
@@ -197,7 +197,7 @@ pub async fn create_pty_session(config: ShellConfig) -> Result<SharedPtySession>
 /// - Provides async methods that properly handle mutex locking and PTY operations
 ///
 /// **Usage Pattern:**
-/// ```rust,no_run
+/// ```rust,no_run,ignore
 /// let config = ShellConfig::default();
 /// let manager = PtySessionManager::new(config).await?;
 ///


### PR DESCRIPTION
The following three commits adds some additional portability to the program as well as makes the program installable by Nix users.  They are broken up to help review/history.
- 6d213704c88efdd47b04c941b592648e36388927 adds a Nix derivation (essentially a Nix "package"), which can be referenced easily via a Nix flake.  It also includes a `nix develop` setup, which allows Nix contributors to use a consistent development environment.
- 54c774c69021dd023aff9cf480e47c86bac4c0c3 excludes some example code from being treated as doc tests (`cargo test --doc`).
- d22b31f29937452397950b7b7628e206eace9f4d makes the `--shell` argument more portable by essentially doing `which bash` with some intelligent fallbacks.  This should be helpful for many ecosystems, including those managed by Homebrew.